### PR TITLE
Add Microchip SAM D21/DA1 peripheral size static assertions

### DIFF
--- a/source/picolibrary/microchip/sam/d21da1/peripheral/paca.cc
+++ b/source/picolibrary/microchip/sam/d21da1/peripheral/paca.cc
@@ -21,3 +21,9 @@
  */
 
 #include "picolibrary/microchip/sam/d21da1/peripheral/paca.h"
+
+namespace picolibrary::Microchip::SAM::D21DA1::Peripheral {
+
+static_assert( sizeof( PACA ) == 0x04 + 4 );
+
+} // namespace picolibrary::Microchip::SAM::D21DA1::Peripheral

--- a/source/picolibrary/microchip/sam/d21da1/peripheral/pacb.cc
+++ b/source/picolibrary/microchip/sam/d21da1/peripheral/pacb.cc
@@ -21,3 +21,9 @@
  */
 
 #include "picolibrary/microchip/sam/d21da1/peripheral/pacb.h"
+
+namespace picolibrary::Microchip::SAM::D21DA1::Peripheral {
+
+static_assert( sizeof( PACB ) == 0x04 + 4 );
+
+} // namespace picolibrary::Microchip::SAM::D21DA1::Peripheral

--- a/source/picolibrary/microchip/sam/d21da1/peripheral/pacc.cc
+++ b/source/picolibrary/microchip/sam/d21da1/peripheral/pacc.cc
@@ -21,3 +21,9 @@
  */
 
 #include "picolibrary/microchip/sam/d21da1/peripheral/pacc.h"
+
+namespace picolibrary::Microchip::SAM::D21DA1::Peripheral {
+
+static_assert( sizeof( PACC ) == 0x04 + 4 );
+
+} // namespace picolibrary::Microchip::SAM::D21DA1::Peripheral

--- a/source/picolibrary/microchip/sam/d21da1/peripheral/systick.cc
+++ b/source/picolibrary/microchip/sam/d21da1/peripheral/systick.cc
@@ -21,3 +21,9 @@
  */
 
 #include "picolibrary/microchip/sam/d21da1/peripheral/systick.h"
+
+namespace picolibrary::Microchip::SAM::D21DA1::Peripheral {
+
+static_assert( sizeof( SYSTICK ) == ( 0xE000E01C - 0xE000E010 ) + 4 );
+
+} // namespace picolibrary::Microchip::SAM::D21DA1::Peripheral


### PR DESCRIPTION
Resolves #22 (Add Microchip SAM D21/DA1 peripheral size static assertions).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
