### PR TITLE
Add Microchip SAM D21/DA1 default interrupt vector table instance

### DIFF
--- a/docs/interrupt.md
+++ b/docs/interrupt.md
@@ -4,3 +4,98 @@ Microchip SAM D21/DA1 interrupt facilities are defined in the
 header/source file pair.
 
 ## Table of Contents
+- [Default Vector Table](#default-vector-table)
+
+## Default Vector Table
+The default vector table instance provided by picolibrary-microchip-sam-d21da1 is placed
+in the `.vectors` section and is populated as follows:
+- Initial stack pointer value: `_stack_end` (must be defined by linker script)
+- Reset handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset()`
+- NMI handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nmi()`
+- Hard fault handler:
+  `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_hard_fault()`
+- SVCALL handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_svcall()`
+- PENDSV handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pendsv()`
+- SYSTICK0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_systick0()`
+- PM0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pm0()`
+- SYSCTRL0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sysctrl0()`
+- WDT0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_wdt0()`
+- RTC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_rtc0()`
+- EIC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_eic0()`
+- NVMCTRL0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nvmctrl0()`
+- DMAC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dmac0()`
+- USB0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_usb0()`
+- EVSYS0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_evsys0()`
+- SERCOM0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom0()`
+- SERCOM1 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom1()`
+- SERCOM2 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom2()`
+- SERCOM3 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom3()`
+- SERCOM4 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom4()`
+- SERCOM5 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom5()`
+- TCC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc0()`
+- TCC1 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc1()`
+- TCC2 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc2()`
+- TC3 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc3()`
+- TC4 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc4()`
+- TC5 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc5()`
+- TC6 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc6()`
+- TC7 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc7()`
+- ADC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_adc0()`
+- AC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac0()`
+- DAC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dac0()`
+- PTC0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ptc0()`
+- I2S0 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_i2s0()`
+- AC1 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac1()`
+- TCC3 handler: `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc3()`
+
+`::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset()` is defined as a weak
+alias for `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset_default()` so
+that its behavior can be overridden.
+
+`::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset_default()` uses the
+following linker defined symbols:
+- `_data_flash_start`: The start of the data used to initialize the `.data` section
+- `_data_start`: The start of the `.data` section
+- `_data_end`: The end of the `.data` section
+- `_bss_start`: The start of the `.bss` section
+- `_bss_end`: The end of the `.bss` section
+- `_vector_table`: The start of the default vector table
+
+The following functions are defined as weak aliases for
+`::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()` so that
+their behavior can be overridden:
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nmi()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_hard_fault()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_svcall()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pendsv()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_systick0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pm0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sysctrl0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_wdt0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_rtc0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_eic0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nvmctrl0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dmac0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_usb0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_evsys0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom1()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom2()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom3()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom4()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom5()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc1()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc2()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc3()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc4()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc5()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc6()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc7()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_adc0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dac0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ptc0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_i2s0()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac1()`
+- `::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc3()`

--- a/include/picolibrary/microchip/sam/d21da1/interrupt.h
+++ b/include/picolibrary/microchip/sam/d21da1/interrupt.h
@@ -27,6 +27,377 @@
  * \brief Microchip SAM D21/DA1 interrupt facilities.
  */
 namespace picolibrary::Microchip::SAM::D21DA1::Interrupt {
+
+/**
+ * \brief Handle reset (default implementation).
+ */
+void handle_reset_default() noexcept;
+
+/**
+ * \brief Handle reset.
+ *
+ * \attention The default vector table's reset handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset_default() so
+ *            that its behavior can be overridden.
+ */
+void handle_reset() noexcept;
+
+/**
+ * \brief Handle interrupt (default implementation).
+ */
+void handle_interrupt_default() noexcept;
+
+/**
+ * \brief Handle NMI.
+ *
+ * \attention The default vector table's NMI handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_nmi() noexcept;
+
+/**
+ * \brief Handle hard fault.
+ *
+ * \attention The default vector table's hard fault handler entry points to this function.
+ *            It is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_hard_fault() noexcept;
+
+/**
+ * \brief Handle SVCALL.
+ *
+ * \attention The default vector table's SVCALL handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_svcall() noexcept;
+
+/**
+ * \brief Handle PENDSV.
+ *
+ * \attention The default vector table's PENDSV handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_pendsv() noexcept;
+
+/**
+ * \brief Handle SYSTICK0.
+ *
+ * \attention The default vector table's SYSTICK0 handler entry points to this function.
+ *            It is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_systick0() noexcept;
+
+/**
+ * \brief Handle PM0.
+ *
+ * \attention The default vector table's PM0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_pm0() noexcept;
+
+/**
+ * \brief Handle SYSCTRL0.
+ *
+ * \attention The default vector table's SYSCTRL0 handler entry points to this function.
+ *            It is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sysctrl0() noexcept;
+
+/**
+ * \brief Handle WDT0.
+ *
+ * \attention The default vector table's WDT0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_wdt0() noexcept;
+
+/**
+ * \brief Handle RTC0.
+ *
+ * \attention The default vector table's RTC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_rtc0() noexcept;
+
+/**
+ * \brief Handle EIC0.
+ *
+ * \attention The default vector table's EIC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_eic0() noexcept;
+
+/**
+ * \brief Handle NVMCTRL0.
+ *
+ * \attention The default vector table's NVMCTRL0 handler entry points to this function.
+ *            It is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_nvmctrl0() noexcept;
+
+/**
+ * \brief Handle DMAC0.
+ *
+ * \attention The default vector table's DMAC0 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_dmac0() noexcept;
+
+/**
+ * \brief Handle USB0.
+ *
+ * \attention The default vector table's USB0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_usb0() noexcept;
+
+/**
+ * \brief Handle EVSYS0.
+ *
+ * \attention The default vector table's EVSYS0 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_evsys0() noexcept;
+
+/**
+ * \brief Handle SERCOM0.
+ *
+ * \attention The default vector table's SERCOM0 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom0() noexcept;
+
+/**
+ * \brief Handle SERCOM1.
+ *
+ * \attention The default vector table's SERCOM1 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom1() noexcept;
+
+/**
+ * \brief Handle SERCOM2.
+ *
+ * \attention The default vector table's SERCOM2 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom2() noexcept;
+
+/**
+ * \brief Handle SERCOM3.
+ *
+ * \attention The default vector table's SERCOM3 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom3() noexcept;
+
+/**
+ * \brief Handle SERCOM4.
+ *
+ * \attention The default vector table's SERCOM4 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom4() noexcept;
+
+/**
+ * \brief Handle SERCOM5.
+ *
+ * \attention The default vector table's SERCOM5 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_sercom5() noexcept;
+
+/**
+ * \brief Handle TCC0.
+ *
+ * \attention The default vector table's TCC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tcc0() noexcept;
+
+/**
+ * \brief Handle TCC1.
+ *
+ * \attention The default vector table's TCC1 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tcc1() noexcept;
+
+/**
+ * \brief Handle TCC2.
+ *
+ * \attention The default vector table's TCC2 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tcc2() noexcept;
+
+/**
+ * \brief Handle TC3.
+ *
+ * \attention The default vector table's TC3 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tc3() noexcept;
+
+/**
+ * \brief Handle TC4.
+ *
+ * \attention The default vector table's TC4 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tc4() noexcept;
+
+/**
+ * \brief Handle TC5.
+ *
+ * \attention The default vector table's TC5 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tc5() noexcept;
+
+/**
+ * \brief Handle TC6.
+ *
+ * \attention The default vector table's TC6 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tc6() noexcept;
+
+/**
+ * \brief Handle TC7.
+ *
+ * \attention The default vector table's TC7 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tc7() noexcept;
+
+/**
+ * \brief Handle ADC0.
+ *
+ * \attention The default vector table's ADC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_adc0() noexcept;
+
+/**
+ * \brief Handle AC0.
+ *
+ * \attention The default vector table's AC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_ac0() noexcept;
+
+/**
+ * \brief Handle DAC0.
+ *
+ * \attention The default vector table's DAC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_dac0() noexcept;
+
+/**
+ * \brief Handle PTC0.
+ *
+ * \attention The default vector table's PTC0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_ptc0() noexcept;
+
+/**
+ * \brief Handle I2S0.
+ *
+ * \attention The default vector table's I2S0 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_i2s0() noexcept;
+
+/**
+ * \brief Handle AC10.
+ *
+ * \attention The default vector table's AC10 handler entry points to this function. It is
+ *            defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_ac1() noexcept;
+
+/**
+ * \brief Handle TCC30.
+ *
+ * \attention The default vector table's TCC30 handler entry points to this function. It
+ *            is defined as a weak alias for
+ *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
+ *            so that its behavior can be overridden.
+ */
+void handle_tcc3() noexcept;
+
 } // namespace picolibrary::Microchip::SAM::D21DA1::Interrupt
 
 #endif // PICOLIBRARY_MICROCHIP_SAM_D21DA1_INTERRUPT_H

--- a/include/picolibrary/microchip/sam/d21da1/interrupt.h
+++ b/include/picolibrary/microchip/sam/d21da1/interrupt.h
@@ -379,9 +379,9 @@ void handle_ptc0() noexcept;
 void handle_i2s0() noexcept;
 
 /**
- * \brief Handle AC10.
+ * \brief Handle AC1.
  *
- * \attention The default vector table's AC10 handler entry points to this function. It is
+ * \attention The default vector table's AC1 handler entry points to this function. It is
  *            defined as a weak alias for
  *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
  *            so that its behavior can be overridden.
@@ -389,10 +389,10 @@ void handle_i2s0() noexcept;
 void handle_ac1() noexcept;
 
 /**
- * \brief Handle TCC30.
+ * \brief Handle TCC3.
  *
- * \attention The default vector table's TCC30 handler entry points to this function. It
- *            is defined as a weak alias for
+ * \attention The default vector table's TCC3 handler entry points to this function. It is
+ *            defined as a weak alias for
  *            picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_interrupt_default()
  *            so that its behavior can be overridden.
  */

--- a/source/picolibrary/microchip/sam/d21da1/interrupt.cc
+++ b/source/picolibrary/microchip/sam/d21da1/interrupt.cc
@@ -78,25 +78,20 @@ extern "C" void picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default(
     for ( ;; ) {} // for
 }
 
-#define HANDLE_RESET_DEFAULT_ALIAS \
-    __attribute__(                 \
-        ( alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
-
-#define HANDLE_RESET_DEFAULT_WEAK_ALIAS \
-    __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
+// clang-format off
+#define HANDLE_RESET_DEFAULT_ALIAS      __attribute__( (       alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
+#define HANDLE_RESET_DEFAULT_WEAK_ALIAS __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
+// clang-format on
 
 extern "C" void picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default() noexcept
 {
     for ( ;; ) {} // for
 }
 
-#define HANDLE_INTERRUPT_DEFAULT_ALIAS                                          \
-    __attribute__(                                                              \
-        ( alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_" \
-                 "default" ) ) )
-
-#define HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS \
-    __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default" ) ) )
+// clang-format off
+#define HANDLE_INTERRUPT_DEFAULT_ALIAS      __attribute__( (       alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default" ) ) )
+#define HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default" ) ) )
+// clang-format on
 
 namespace picolibrary::Microchip::SAM::D21DA1::Interrupt {
 

--- a/source/picolibrary/microchip/sam/d21da1/interrupt.cc
+++ b/source/picolibrary/microchip/sam/d21da1/interrupt.cc
@@ -42,6 +42,8 @@ int main();
 
 extern "C" void picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default() noexcept
 {
+    // #lizard forgives the length
+
     {
         auto const *       data_flash_start = &_data_flash_start;
         auto *             data_start       = &_data_start;

--- a/source/picolibrary/microchip/sam/d21da1/interrupt.cc
+++ b/source/picolibrary/microchip/sam/d21da1/interrupt.cc
@@ -21,3 +21,216 @@
  */
 
 #include "picolibrary/microchip/sam/d21da1/interrupt.h"
+
+#include <cstdint>
+
+#include "picolibrary/arm/cortex/m0plus/interrupt.h"
+#include "picolibrary/arm/cortex/m0plus/peripheral.h"
+#include "picolibrary/microchip/sam/d21da1/peripheral.h"
+#include "picolibrary/microchip/sam/d21da1/peripheral/nvmctrl.h"
+
+extern std::uint32_t _data_flash_start;
+extern std::uint32_t _data_start;
+extern std::uint32_t _data_end;
+extern std::uint32_t _bss_start;
+extern std::uint32_t _bss_end;
+extern std::uint32_t _vector_table;
+
+void __libc_init_array();
+
+int main();
+
+extern "C" void picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default() noexcept
+{
+    {
+        auto const *       data_flash_start = &_data_flash_start;
+        auto *             data_start       = &_data_start;
+        auto const * const data_end         = &_data_end;
+
+        if ( data_start != data_flash_start ) {
+            for ( ; data_start != data_end; ++data_flash_start, ++data_start ) {
+                *data_start = *data_flash_start;
+            } // if
+        }     // if
+    }
+
+    {
+        auto *             bss_start = &_bss_start;
+        auto const * const bss_end   = &_bss_end;
+
+        for ( ; bss_start != bss_end; ++bss_start ) { *bss_start = 0; } // for
+    }
+
+    static_assert( sizeof( std::uint32_t * ) == sizeof( std::uint32_t ) );
+    ::picolibrary::Arm::Cortex::M0PLUS::Peripheral::SCB0::instance().vtor =
+        reinterpret_cast<std::uint32_t>( &_vector_table );
+
+    // Silicon errata workaround ("Spurious Writes")
+    ::picolibrary::Microchip::SAM::D21DA1::Peripheral::NVMCTRL0::instance().ctrlb |=
+        ::picolibrary::Microchip::SAM::D21DA1::Peripheral::NVMCTRL::CTRLB::Mask::MANW;
+
+    __libc_init_array();
+
+    main();
+
+    for ( ;; ) {} // for
+}
+
+#define HANDLE_RESET_DEFAULT_ALIAS \
+    __attribute__(                 \
+        ( alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
+
+#define HANDLE_RESET_DEFAULT_WEAK_ALIAS \
+    __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_reset_default" ) ) )
+
+extern "C" void picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default() noexcept
+{
+    for ( ;; ) {} // for
+}
+
+#define HANDLE_INTERRUPT_DEFAULT_ALIAS                                          \
+    __attribute__(                                                              \
+        ( alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_" \
+                 "default" ) ) )
+
+#define HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS \
+    __attribute__( ( weak, alias( "picolibrary_microchip_sam_d21da1_interrupt_handle_interrupt_default" ) ) )
+
+namespace picolibrary::Microchip::SAM::D21DA1::Interrupt {
+
+void handle_reset_default() HANDLE_RESET_DEFAULT_ALIAS;
+
+void handle_reset() HANDLE_RESET_DEFAULT_WEAK_ALIAS;
+
+void handle_interrupt_default() HANDLE_INTERRUPT_DEFAULT_ALIAS;
+
+void handle_nmi() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_hard_fault() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_svcall() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_pendsv() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_systick0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_pm0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sysctrl0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_wdt0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_rtc0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_eic0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_nvmctrl0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_dmac0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_usb0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_evsys0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom1() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom2() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom3() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom4() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_sercom5() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tcc0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tcc1() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tcc2() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tc3() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tc4() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tc5() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tc6() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tc7() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_adc0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_ac0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_dac0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_ptc0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_i2s0() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_ac1() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+void handle_tcc3() HANDLE_INTERRUPT_DEFAULT_WEAK_ALIAS;
+
+} // namespace picolibrary::Microchip::SAM::D21DA1::Interrupt
+
+extern std::uint32_t _stack_end;
+
+namespace {
+
+auto const VECTOR_TABLE __attribute__( (
+    section( ".vectors" ) ) ) = ::picolibrary::Arm::Cortex::M0PLUS::Interrupt::Vector_Table{
+    .stack = &_stack_end,
+
+    .reset_handler = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_reset,
+
+    .nmi_handler        = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nmi,
+    .hard_fault_handler = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_hard_fault,
+    .reserved_n12       = nullptr,
+    .reserved_n11       = nullptr,
+    .reserved_n10       = nullptr,
+    .reserved_n9        = nullptr,
+    .reserved_n8        = nullptr,
+    .reserved_n7        = nullptr,
+    .reserved_n6        = nullptr,
+    .svcall_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_svcall,
+    .reserved_n4        = nullptr,
+    .reserved_n3        = nullptr,
+    .pendsv_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pendsv,
+    .systick0_handler = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_systick0,
+
+    .pm0_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_pm0,
+    .sysctrl0_handler = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sysctrl0,
+    .wdt0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_wdt0,
+    .rtc0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_rtc0,
+    .eic0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_eic0,
+    .nvmctrl0_handler = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_nvmctrl0,
+    .dmac0_handler    = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dmac0,
+    .usb0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_usb0,
+    .evsys0_handler   = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_evsys0,
+    .sercom0_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom0,
+    .sercom1_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom1,
+    .sercom2_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom2,
+    .sercom3_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom3,
+    .sercom4_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom4,
+    .sercom5_handler  = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_sercom5,
+    .tcc0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc0,
+    .tcc1_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc1,
+    .tcc2_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc2,
+    .tc3_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc3,
+    .tc4_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc4,
+    .tc5_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc5,
+    .tc6_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc6,
+    .tc7_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tc7,
+    .adc0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_adc0,
+    .ac0_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac0,
+    .dac0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_dac0,
+    .ptc0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ptc0,
+    .i2s0_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_i2s0,
+    .ac1_handler      = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_ac1,
+    .tcc3_handler     = ::picolibrary::Microchip::SAM::D21DA1::Interrupt::handle_tcc3,
+};
+
+} // namespace


### PR DESCRIPTION
Resolves #56 (Add Microchip SAM D21/DA1 default interrupt vector table instance).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
